### PR TITLE
Add a PULL_REQUEST_TEMPLATE.md to get rid of the current annoying template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-----------------------------------------------------------------------------
+Thank you for contributing to the PrestaShop Specifications! 
+
+Please take the time to edit the "Answers" rows below with the necessary information.
+------------------------------------------------------------------------------>
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
+| Fixed ticket? | Fixes #{issue number here} if there is a related issue
+
+<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

The template being used for PRs below is annoying 🙄 because it has nothing to do with this repository. This is obviously a template for coding repositories. See:
```
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?         | bug fix / improvement / new feature / refacto
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes {paste the issue here}.
| How to test?  | Please indicate how to best verify that this PR is correct.
```

I suggest using a simpler template like [this one](https://github.com/PrestaShop/docs/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
