### PR TITLE
Add the overrides list to the Information specs

### DIFF
--- a/back-office/advanced-parameters/information/information.md
+++ b/back-office/advanced-parameters/information/information.md
@@ -1,0 +1,10 @@
+# **SPECIFICATIONS - INFORMATION PAGE**
+
+
+[TO BE COMPLETED]
+
+## List of overrides
+
+_As a developer/merchant, I want to be able to know what PrestaShop behavior is overridden._
+
+As for the list of changed files, the Advanced Parameters > Information page should display the **list of overrides**.


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add the list of overrides to the Advanced Parameters > Information page specifications, following the two tickets mentioned below.
| Fixed ticket? | Related to the https://github.com/PrestaShop/PrestaShop/issues/21368 issue and https://github.com/PrestaShop/PrestaShop/pull/21375 PR.