### PR TITLE
Add the friendly URL option to the SEO & URLs page

### DIFF
--- a/back-office/shop-parameters/traffic-and-seo/seo-and-urls-page.md
+++ b/back-office/shop-parameters/traffic-and-seo/seo-and-urls-page.md
@@ -8,6 +8,15 @@ _MetaGridDefinitionFactory.php_ Default action in the button: Edit Other availab
 Row action does not apply to the ID's checkbox column.
 
 
+## SEO & URLs
+
+[TO BE COMPLETED]
+
+**Rewritten URL.** Should be available for all pages, even the _index_ which stands for the store's homepage.
+
+[TO BE COMPLETED]
+
+
 ## URLs set up
 
 **Friendly URL.** By default, this option is enabled. A friendly URL is generated from the page/item name, it is **available for all of the pages whose URL can be rewritten**:

--- a/back-office/shop-parameters/traffic-and-seo/seo-and-urls-page.md
+++ b/back-office/shop-parameters/traffic-and-seo/seo-and-urls-page.md
@@ -1,0 +1,22 @@
+# **SPECIFICATIONS - SEO & URLS PAGE**
+
+
+## Grid
+
+_MetaGridDefinitionFactory.php_ Default action in the button: Edit Other available actions in the menu: Delete Row action: Edit
+
+Row action does not apply to the ID's checkbox column.
+
+
+## URLs set up
+
+[TO BE COMPLETED]
+
+**Force update of friendly URL.** At first, this option was only available for products, in the Shop Parameters > Product Settings page but it has been decided to make it available for all URLs. So it is now a SEO & URLs parameter to be found in this dedicated section of the back office, cf. _to do_ issue #[21386](https://github.com/PrestaShop/PrestaShop/issues/21386).
+
+A friendly URL is generated from the page/item name. By default, it is disabled. Enabling this option will **automatically regenerate it every time the merchant modifies it and saves a new name**. As a consequence, it automatically updates the friendly URL column in the 'SEO & URLs' listing of the page.
+
+:pushpin: Example: the merchant edits the name of a product, he/she turns 'Mug the best is yet to come' into 'Mug the best has gone' - sad story, I know.
+
+Case 1, this option stays disabled: the product name has changed but the URL still contains `rewrite=mug-the-best-is-yet-to-come`.</br>
+Case 2, this option is enabled: the product name has changed and the URL now contains `rewrite=mug-the-best-has-gone`.

--- a/back-office/shop-parameters/traffic-and-seo/seo-and-urls-page.md
+++ b/back-office/shop-parameters/traffic-and-seo/seo-and-urls-page.md
@@ -10,11 +10,22 @@ Row action does not apply to the ID's checkbox column.
 
 ## URLs set up
 
-[TO BE COMPLETED]
+**Friendly URL.** By default, this option is enabled. A friendly URL is generated from the page/item name, it is **available for all of the pages whose URL can be rewritten**:
+
+- product
+- category
+- attribute
+- feature
+- brand
+- supplier
+- page
+- page category
+
+A tooltip completes this feature, _Enable this option only if your server allows URL rewriting (recommended)._.
 
 **Force update of friendly URL.** At first, this option was only available for products, in the Shop Parameters > Product Settings page but it has been decided to make it available for all URLs. So it is now a SEO & URLs parameter to be found in this dedicated section of the back office, cf. _to do_ issue #[21386](https://github.com/PrestaShop/PrestaShop/issues/21386).
 
-A friendly URL is generated from the page/item name. By default, it is disabled. Enabling this option will **automatically regenerate it every time the merchant modifies it and saves a new name**. As a consequence, it automatically updates the friendly URL column in the 'SEO & URLs' listing of the page.
+By default, it is disabled. Enabling this option will **automatically regenerate the URL every time the merchant modifies it to save a new name**. As a consequence, it automatically updates the friendly URL column in the 'SEO & URLs' listing of the page.
 
 :pushpin: Example: the merchant edits the name of a product, he/she turns 'Mug the best is yet to come' into 'Mug the best has gone' - sad story, I know.
 

--- a/back-office/shop-parameters/traffic-and-seo/shop_parameters-traffic_and_seo-seo_and_urls.md
+++ b/back-office/shop-parameters/traffic-and-seo/shop_parameters-traffic_and_seo-seo_and_urls.md
@@ -1,8 +1,0 @@
-# SPECIFICATIONS - SHOP PARAMETERS &gt; TRAFFIC & SEO &gt; SEO & URLS
-
-## Grid
-
-_MetaGridDefinitionFactory.php_ Default action in the button: Edit Other available actions in the menu: Delete Row action: Edit
-
-Row action does not apply to the ID's checkbox column.
-


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Extend the use of the 'force update of friendly URL' option to all items and add it to the SEO & URLs page
| Fixed ticket? | Related to https://github.com/PrestaShop/PrestaShop/issues/21386 & https://github.com/PrestaShop/PrestaShop/issues/14336

Here is a screenshot example of the expected _Shop Parameters > SEO & URLs_ page:

<img width="1548" alt="Capture d’écran 2020-10-13 à 15 49 46" src="https://user-images.githubusercontent.com/32565890/95869931-33b41100-0d6c-11eb-97fb-292eb57c4e78.png">

⚠️ Do not forget to check to _Product Settings_ specifications before the merge to make sure this option does not appear anymore. ;-)