### PR TITLE
Specify the FO behavior at the payment step

### DIFF
--- a/front-office/checkout.md
+++ b/front-office/checkout.md
@@ -1,0 +1,8 @@
+# **SPECIFICATIONS - CHECKOUT**
+
+
+[TO BE COMPLETED]
+
+## Payment step
+
+If the store has only one payment method available, this payment method should be selected by default.


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When a shop has only one payment method activated, this payment method could be selected by default at checkout
| Fixed ticket? | Related to https://github.com/PrestaShop/PrestaShop/issues/11435
