### PR TITLE
Specify the default language for order documents

### DIFF
--- a/back-office/orders/orders/Order Page View.md
+++ b/back-office/orders/orders/Order Page View.md
@@ -80,6 +80,8 @@ The user gets access to the order view page by either clicking on **the order’
 On the header, we have **the order’s reference, customer’s name, total price in black background, the date and the hour**.
 All date and time formats are defined according to CLDR and the display language.
 
+Order documents like invoices and delivery slips are, by default, in the customer language. An option allows merchants to turn it into the logistician language in the Shop Parameters > Order Settings page, cf. issue #[10258](https://github.com/PrestaShop/PrestaShop/issues/10258).
+
 ## I. **Action panel**
 
 **Below the panel’s header**, we have all the order's action button:

--- a/front-office/customer-account.md
+++ b/front-office/customer-account.md
@@ -1,0 +1,10 @@
+# **SPECIFICATIONS - CUSTOMER ACCOUNT**
+
+
+[TO BE COMPLETED]
+
+## Order history and details
+
+_As a customer, I want to be able to access my order documents in my personal account._
+
+Logged-in customers should view and download their invoices and delivery slips in their language (= in the language used by the customers in the front office).


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Specify what should be the default language used in the customer's personal account in the FO and on the order view page in the BO.
| Fixed ticket? | Related to https://github.com/PrestaShop/PrestaShop/issues/10258, cf. point A et C.