### PR TITLE
Enable store for logged-in employees

### DIFF
--- a/back-office/shop-parameters/general/maintenance.md
+++ b/back-office/shop-parameters/general/maintenance.md
@@ -9,11 +9,11 @@ _As a merchant, I want to be able to turn my store offline to perform maintenanc
 
 During maintenance, the webservice remains enabled. Users with a key can still retrieve data. If need be, the webservice is to disable in Advanced Parameters > Webservice.
 
-**Enable store for logged-in employees.** By default, this setting is enabled. When an employee is logged in, his/her **IP address should automatically be allowed to access the front office**, even if the shop is disabled. A help text is available: `Allow logged in employees to access the store, even in maintenance mode.` in `Admin.Shopparameters.Help`.
+**Enable store for logged-in employees.** By default, this setting is enabled. When an employee is logged in, his/her **IP address should automatically be allowed to access the front office**, even if the shop is disabled. A help text is available: `Allow logged-in employees to access the store, even in maintenance mode.` in `Admin.Shopparameters.Help`.
 
 **Maintenance IP.** It **allows specific IP addresses to access the store even if it is disabled**. Clicking `Add my IP` should automatically fetch the IP address of the current computer. Users can add as many IP addresses as they need as long as separated with commas (,).
 
-A help text is available: `IP addresses allowed to access the front office even if the shop is disabled. Please use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96).` in `Admin.Shopparameters.Help`.
+A help text is available: `Allow IP addresses to access the store, even in maintenance mode. Use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96).` in `Admin.Shopparameters.Help`.
 
 **Custom maintenance text.** Users can **display a message on the maintenance page** by using a text editor. By default, the following message is displayed: `We are currently updating our shop and will be back really soon. Thanks for your patience.` in `Admin.Shopparameters.Feature`. Merchants can localize the label according to the store's available languages.
 

--- a/back-office/shop-parameters/general/maintenance.md
+++ b/back-office/shop-parameters/general/maintenance.md
@@ -7,6 +7,6 @@ _As a merchant, I want to be able to turn my store offline to perform maintenanc
 
 [TO BE COMPLETED]
 
-**Enable store for logged-in employees.** By default, this setting is enabled. When an employee is logged in, his/her **IP address should automatically be allowed to access the front office**, even if the shop is disabled. A help text is available: `Allow logged in employees to access the store, even in maintenance mode.` in `Admin.Shopparameters.Feature`.
+**Enable store for logged-in employees.** By default, this setting is enabled. When an employee is logged in, his/her **IP address should automatically be allowed to access the front office**, even if the shop is disabled. A help text is available: `Allow logged in employees to access the store, even in maintenance mode.` in `Admin.Shopparameters.Help`.
 
 [TO BE COMPLETED]

--- a/back-office/shop-parameters/general/maintenance.md
+++ b/back-office/shop-parameters/general/maintenance.md
@@ -5,8 +5,25 @@ _As a merchant, I want to be able to turn my store offline to perform maintenanc
 
 ## General
 
-[TO BE COMPLETED]
+**Enable store.** Merchants have the **possibility to temporarily disable their shop**. It should only disable the front office, the back office is still accessible during maintenance. A help text is available: `We recommend that you deactivate your store while performing maintenance. Note that it will not disable the webservice.` in `Admin.Shopparameters.Help`.
+
+During maintenance, the webservice remains enabled. Users with a key can still retrieve data. If need be, the webservice is to disable in Advanced Parameters > Webservice.
 
 **Enable store for logged-in employees.** By default, this setting is enabled. When an employee is logged in, his/her **IP address should automatically be allowed to access the front office**, even if the shop is disabled. A help text is available: `Allow logged in employees to access the store, even in maintenance mode.` in `Admin.Shopparameters.Help`.
+
+**Maintenance IP.** It **allows specific IP addresses to access the store even if it is disabled**. Clicking `Add my IP` should automatically fetch the IP address of the current computer. Users can add as many IP addresses as they need as long as separated with commas (,).
+
+A help text is available: `IP addresses allowed to access the front office even if the shop is disabled. Please use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96).` in `Admin.Shopparameters.Help`.
+
+**Custom maintenance text.** Users can **display a message on the maintenance page**. By default, it is limited to 21844 characters. If the input contains more than 21844 characters, an error notification should be displayed when saving: `%1$s is too long. Maximum length: %2$d` in `Admin.Notifications.Error`.
+
+Leaving this field empty disables the feature. Merchants can localize the label according to the store's available languages.
+
+No help text available, the placeholder indicates users why to fill this field: `Write a customized message for the customers to read when the store is disabled.` in `Admin.Shopparameters.Help`.
+
+Clicking 'Save', users are expected to stay on this page and see a success notification, `Update successful` in `Admin.Notifications.Success`.
+
+
+## Multistore behavior
 
 [TO BE COMPLETED]

--- a/back-office/shop-parameters/general/maintenance.md
+++ b/back-office/shop-parameters/general/maintenance.md
@@ -15,7 +15,7 @@ During maintenance, the webservice remains enabled. Users with a key can still r
 
 A help text is available: `Allow IP addresses to access the store, even in maintenance mode. Use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96).` in `Admin.Shopparameters.Help`.
 
-**Custom maintenance text.** Users can **display a message on the maintenance page** by using a text editor. By default, the following message is displayed: `We are currently updating our shop and will be back really soon. Thanks for your patience.` in `Admin.Shopparameters.Feature`. Merchants can localize the label according to the store's available languages.
+**Custom maintenance text.** Users can **display a message on the maintenance page** by using a text editor. By default, the following message is displayed: `We are currently updating our shop and will be back really soon. Thanks for your patience.` in `Admin.Shopparameters.Feature`. Merchants can localize the message according to the store's available languages.
 
 It is limited to 21844 characters. If the input contains more than 21844 characters, an error notification should be displayed when clicking 'Save' (and prevent from saving): `%1$s is too long. Maximum length: %2$d` in `Admin.Notifications.Error`.
 

--- a/back-office/shop-parameters/general/maintenance.md
+++ b/back-office/shop-parameters/general/maintenance.md
@@ -15,11 +15,11 @@ During maintenance, the webservice remains enabled. Users with a key can still r
 
 A help text is available: `IP addresses allowed to access the front office even if the shop is disabled. Please use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96).` in `Admin.Shopparameters.Help`.
 
-**Custom maintenance text.** Users can **display a message on the maintenance page**. By default, it is limited to 21844 characters. If the input contains more than 21844 characters, an error notification should be displayed when saving: `%1$s is too long. Maximum length: %2$d` in `Admin.Notifications.Error`.
+**Custom maintenance text.** Users can **display a message on the maintenance page** by using a text editor. By default, the following message is displayed: `We are currently updating our shop and will be back really soon. Thanks for your patience.` in `Admin.Shopparameters.Feature`. Merchants can localize the label according to the store's available languages.
 
-Leaving this field empty disables the feature. Merchants can localize the label according to the store's available languages.
+It is limited to 21844 characters. If the input contains more than 21844 characters, an error notification should be displayed when clicking 'Save' (and prevent from saving): `%1$s is too long. Maximum length: %2$d` in `Admin.Notifications.Error`.
 
-No help text available, the placeholder indicates users why to fill this field: `Write a customized message for the customers to read when the store is disabled.` in `Admin.Shopparameters.Help`.
+A help text is available: `Display a customized message when the store is disabled.` in `Admin.Shopparameters.Help`.
 
 Clicking 'Save', users are expected to stay on this page and see a success notification, `Update successful` in `Admin.Notifications.Success`.
 

--- a/back-office/shop-parameters/general/maintenance.md
+++ b/back-office/shop-parameters/general/maintenance.md
@@ -1,0 +1,12 @@
+# **SPECIFICATIONS - MAINTENANCE PAGE**
+
+
+_As a merchant, I want to be able to turn my store offline to perform maintenance._
+
+## General
+
+[TO BE COMPLETED]
+
+**Enable store for logged-in employees.** By default, this setting is enabled. When an employee is logged in, his/her **IP address should automatically be allowed to access the front office**, even if the shop is disabled. A help text is available: `Allow logged in employees to access the store, even in maintenance mode.` in `Admin.Shopparameters.Feature`.
+
+[TO BE COMPLETED]

--- a/front-office/maintenance.md
+++ b/front-office/maintenance.md
@@ -1,0 +1,10 @@
+# **SPECIFICATIONS - MAINTENANCE MODE**
+
+
+## Logged-in employees
+
+_As an employee, I want to be able to access the front office during maintenance._
+
+When the 'Enable store for logged-in employees' option is enabled in the back office's Shop Parameters > Maintenance page, any logged-in employee should be able to access the front office even if the store is in maintenance.
+
+[TO BE COMPLETED]


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Allow logged-in employees to access the front office while the store is in maintenance mode.
| Fixed ticket? | Related to https://github.com/PrestaShop/PrestaShop/issues/18932.
