### PR TITLE
Add #19200 improvement to the Order page specifications

### DIFF
--- a/back-office/orders/orders/Order Page View.md
+++ b/back-office/orders/orders/Order Page View.md
@@ -516,7 +516,7 @@ The edit shipping button on each row can edit the information in a popin. You ca
 
 4.  **Merchandising returns tab**
 
-The merchandise return tab lists **the date, the tracking number, the type, Carrier (which is the return status) and the quantity**. When the merchandise return is disabled the tab displayed: "no merchandise returned yet".
+The merchandise return tab lists **the date, the tracking number, the type, the carrier (= return status), and the number (= return reference number)**. When the merchandise return is disabled the tab displayed: "no merchandise returned yet".
 
 5.  **Payment panel**
 

--- a/back-office/orders/orders/Order Page View.md
+++ b/back-office/orders/orders/Order Page View.md
@@ -516,7 +516,7 @@ The edit shipping button on each row can edit the information in a popin. You ca
 
 4.  **Merchandising returns tab**
 
-The merchandise return tab lists **the date, the tracking number, the type, the carrier (= return status), and the number (= return reference number)**. When the merchandise return is disabled the tab displayed: "no merchandise returned yet".
+The merchandise return tab lists **the date, the type, the carrier (= return status), and the number (= return reference number)**. When the merchandise return is disabled the tab displayed: "no merchandise returned yet".
 
 5.  **Payment panel**
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adds the tracking number in the 'Merchandise returns' tab of an order
| Fixed ticket? | Related to https://github.com/PrestaShop/PrestaShop/issues/19200#issuecomment-756072824