### PR TITLE
blocklayered module route is not used in 1.7

### DIFF
--- a/content/1.7/broader-topics/seo-rules-and-behaviours.md
+++ b/content/1.7/broader-topics/seo-rules-and-behaviours.md
@@ -47,7 +47,6 @@ _Schema of PrestaShop URL (displayed only if friendly URLs are enabled)_
 By default, route to pages are the following :
 - Route to products : {category:/}{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html
 - Route to category : {id}-{rewrite}
-- Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module : {id}-{rewrite}{/:selected_filters}
 - Route to supplier : supplier/{id}-{rewrite}
 - Route to brand : brand/{id}-{rewrite}
 - Route to page : content/{id}-{rewrite}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Specifications! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | blocklayered module route with selected_filters is not used anymore. It was for blocklayered module and this module in not compatible with Prestashop 1.7
| Fixed ticket? | more info here https://github.com/PrestaShop/PrestaShop/pull/24509

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
