### PR TITLE
Add user stories  id_reference carrier

### DIFF
--- a/content/1.7/back-office/shipping/carriers/add-edit.md
+++ b/content/1.7/back-office/shipping/carriers/add-edit.md
@@ -121,5 +121,5 @@ WIP
 
 ## Behaviors / User stories
 
-WIP
+When you edit a carrier a new carrier is created it keeps a link with the old one with the id_reference
 


### PR DESCRIPTION
When you edit a carrier a new carrier is created it keeps a link with the old one with the id_reference

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Specifications! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When you edit a carrier a new carrier is created it keeps a link with the old one with the id_reference
| Fixed ticket? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
